### PR TITLE
Add new method parseDate2(..) with fixed behaviour for Dst offset

### DIFF
--- a/src/main/java/com/github/sisyphsu/dateparser/DateParser.java
+++ b/src/main/java/com/github/sisyphsu/dateparser/DateParser.java
@@ -1,11 +1,15 @@
 package com.github.sisyphsu.dateparser;
 
-import com.github.sisyphsu.retree.ReMatcher;
-
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.github.sisyphsu.retree.ReMatcher;
 
 /**
  * DateParser represents an unique parser context, it shouldn't be used concurrently.
@@ -19,439 +23,463 @@ import java.util.*;
  */
 public final class DateParser {
 
-    private final ReMatcher matcher;
-    private final DateBuilder dt = new DateBuilder();
+	private final ReMatcher matcher;
+	private final DateBuilder dt = new DateBuilder();
 
-    private final List<String> rules;
-    private final Set<String> standardRules;
-    private final Map<String, RuleHandler> customizedRuleMap;
+	private final List<String> rules;
+	private final Set<String> standardRules;
+	private final Map<String, RuleHandler> customizedRuleMap;
 
-    private String input;
-    private boolean preferMonthFirst;
+	private String input;
+	private boolean preferMonthFirst;
 
-    DateParser(List<String> rules, Set<String> stdRules, Map<String, RuleHandler> cstRules, boolean preferMonthFirst) {
-        this.rules = rules;
-        this.standardRules = stdRules;
-        this.customizedRuleMap = cstRules;
-        this.preferMonthFirst = preferMonthFirst;
-        this.matcher = new ReMatcher(this.rules.toArray(new String[0]));
-    }
+	DateParser(List<String> rules, Set<String> stdRules, Map<String, RuleHandler> cstRules, boolean preferMonthFirst) {
+		this.rules = rules;
+		this.standardRules = stdRules;
+		this.customizedRuleMap = cstRules;
+		this.preferMonthFirst = preferMonthFirst;
+		this.matcher = new ReMatcher(this.rules.toArray(new String[0]));
+	}
 
-    /**
-     * Create an new DateParserBuilder which could be used for initialize DateParser.
-     *
-     * @return DateParserBuilder instance
-     */
-    public static DateParserBuilder newBuilder() {
-        return new DateParserBuilder();
-    }
+	/**
+	 * Create an new DateParserBuilder which could be used for initialize DateParser.
+	 *
+	 * @return DateParserBuilder instance
+	 */
+	public static DateParserBuilder newBuilder() {
+		return new DateParserBuilder();
+	}
 
-    /**
-     * If parser cannot distinguish the dd/mm and mm/dd, preferMonthFirst will help it determine.
-     *
-     * @param preferMonthFirst Prefer dd/mm or mm/dd
-     */
-    public void setPreferMonthFirst(boolean preferMonthFirst) {
-        this.preferMonthFirst = preferMonthFirst;
-    }
+	/**
+	 * If parser cannot distinguish the dd/mm and mm/dd, preferMonthFirst will help it determine.
+	 *
+	 * @param preferMonthFirst Prefer dd/mm or mm/dd
+	 */
+	public void setPreferMonthFirst(boolean preferMonthFirst) {
+		this.preferMonthFirst = preferMonthFirst;
+	}
 
-    /**
-     * Parse the specified String into Date
-     *
-     * @param str The original String like '2019-10-01 00:10:20 +0800'
-     * @return The parsed Date
-     */
-    public Date parseDate(String str) {
-        this.dt.reset();
-        this.input = str;
-        this.parse(buildInput(str));
-        return dt.toDate();
-    }
+	/**
+	 * Parse the specified String into Date
+	 *
+	 * @param str The original String like '2019-10-01 00:10:20 +0800'
+	 * @return The parsed Date
+	 */
+	public Date parseDate(String str) {
+		this.dt.reset();
+		this.input = str;
+		this.parse(buildInput(str));
+		return dt.toDate();
+	}
 
-    /**
-     * Parse the specified String into Calendar
-     *
-     * @param str The original String like '2019-10-01 00:10:20 +0800'
-     * @return The parsed Calendar
-     */
-    public Calendar parseCalendar(String str) {
-        this.dt.reset();
-        this.input = str;
-        this.parse(buildInput(str));
-        return dt.toCalendar();
-    }
+	/**
+	 * Parse the specified String into Date. Local JVM Daylight Saving Time(DST) is ignored
+	 * if timezone information is present in parse string
+	 *
+	 * @param str The original String like '2019-10-01 00:10:20 +0800'
+	 * @return The parsed Date
+	 */
+	public Date parseDate2(String str) {
+		this.dt.reset();
+		this.input = str;
+		this.parse(buildInput(str));
+		if (dt.zoneOffsetSetted) {
+			return Date.from(dt.toOffsetDateTime().toInstant());
+		}
+		else {
+			return dt.toDate();
+		}
+	}
 
-    /**
-     * Parse the specified string into LocalDateTime
-     *
-     * @param str The original String
-     * @return The parsed LocalDateTime
-     */
-    public LocalDateTime parseDateTime(String str) {
-        this.dt.reset();
-        this.input = str;
-        this.parse(buildInput(str));
-        return dt.toLocalDateTime();
-    }
+	/**
+	 * Parse the specified String into Calendar
+	 *
+	 * @param str The original String like '2019-10-01 00:10:20 +0800'
+	 * @return The parsed Calendar
+	 */
+	public Calendar parseCalendar(String str) {
+		this.dt.reset();
+		this.input = str;
+		this.parse(buildInput(str));
+		return dt.toCalendar();
+	}
 
-    /**
-     * Parse the specified string into OffsetDateTime
-     *
-     * @param str The original String
-     * @return The parsed OffsetDateTime
-     */
-    public OffsetDateTime parseOffsetDateTime(String str) {
-        this.dt.reset();
-        this.input = str;
-        this.parse(buildInput(str));
-        return dt.toOffsetDateTime();
-    }
+	/**
+	 * Parse the specified string into LocalDateTime
+	 *
+	 * @param str The original String
+	 * @return The parsed LocalDateTime
+	 */
+	public LocalDateTime parseDateTime(String str) {
+		this.dt.reset();
+		this.input = str;
+		this.parse(buildInput(str));
+		return dt.toLocalDateTime();
+	}
 
-    /**
-     * Execute datetime's parsing
-     */
-    private void parse(final CharArray input) {
-        matcher.reset(input);
-        int offset = 0;
-        int oldEnd = -1;
-        while (matcher.find(offset)) {
-            if (oldEnd == matcher.end()) {
-                throw error(offset, "empty matching at " + offset);
-            }
-            if (standardRules.contains(matcher.re())) {
-                this.parseStandard(input, offset);
-            } else {
-                RuleHandler handler = customizedRuleMap.get(matcher.re());
-                handler.handle(input, matcher, dt);
-            }
-            offset = matcher.end();
-            oldEnd = offset;
-        }
-        if (offset != input.length()) {
-            throw error(offset);
-        }
-    }
+	/**
+	 * Parse the specified string into OffsetDateTime
+	 *
+	 * @param str The original String
+	 * @return The parsed OffsetDateTime
+	 */
+	public OffsetDateTime parseOffsetDateTime(String str) {
+		this.dt.reset();
+		this.input = str;
+		this.parse(buildInput(str));
+		return dt.toOffsetDateTime();
+	}
 
-    /**
-     * Parse datetime use standard rules.
-     */
-    void parseStandard(CharArray input, int offset) {
-        for (int index = 1; index <= matcher.groupCount(); index++) {
-            final String groupName = matcher.groupName(index);
-            final int startOff = matcher.start(index);
-            final int endOff = matcher.end(index);
-            if (groupName == null) {
-                throw error(offset, "Hit invalid standard rule: " + matcher.re());
-            }
-            if (startOff == -1 && endOff == -1) {
-                continue;
-            }
-            switch (groupName) {
-                case "week":
-                    dt.week = parseWeek(input, startOff);
-                    break;
-                case "year":
-                    dt.year = parseYear(input, startOff, endOff);
-                    break;
-                case "month":
-                    dt.month = parseMonth(input, startOff, endOff);
-                    if (dt.month <= 0 || dt.month > 12) {
-                        throw error(startOff, "Invalid month at " + startOff);
-                    }
-                    break;
-                case "day":
-                    dt.day = parseNum(input, startOff, endOff);
-                    if (dt.day <= 0 || dt.day > 31) {
-                        throw error(startOff, "Invalid day at " + startOff);
-                    }
-                    break;
-                case "hour":
-                    dt.hour = parseNum(input, startOff, endOff);
-                    if (dt.hour >= 24) {
-                        throw error(startOff, "Invalid hour at " + startOff);
-                    }
-                    break;
-                case "minute":
-                    dt.minute = parseNum(input, startOff, endOff);
-                    if (dt.minute >= 60) {
-                        throw error(startOff, "Invalid minute at " + startOff);
-                    }
-                    break;
-                case "second":
-                    dt.second = parseNum(input, startOff, endOff);
-                    if (dt.second >= 60) {
-                        throw error(startOff, "Invalid second at " + startOff);
-                    }
-                    break;
-                case "ns":
-                    dt.ns = parseNano(input, startOff, endOff);
-                    break;
-                case "m":
-                    if (input.charAt(startOff) == 'p') {
-                        dt.pm = true;
-                    } else {
-                        dt.am = true;
-                    }
-                    break;
-                case "zero":
-                    dt.zoneOffsetSetted = true;
-                    dt.zoneOffset = 0;
-                    break;
-                case "zoneOffset":
-                    dt.zoneOffsetSetted = true;
-                    dt.zoneOffset = parseZoneOffset(input, startOff, endOff);
-                    if (dt.zoneOffset < -1080 || dt.zoneOffset > 1080) {
-                        throw error(startOff, "Invalid ZoneOffset at " + startOff);
-                    }
-                    break;
-                case "zoneName":
-                    // don't support by now
-                    break;
-                case "dayOrMonth":
-                    parseDayOrMonth(input, startOff, endOff);
-                    break;
-                case "unixsecond":
-                    dt.unixsecond = parseNum(input, startOff, startOff + 10);
-                    break;
-                case "millisecond":
-                    dt.unixsecond = parseNum(input, startOff, endOff - 3);
-                    dt.ns = parseNum(input, endOff - 3, endOff) * 1000000;
-                    break;
-                case "microsecond":
-                    dt.unixsecond = parseNum(input, startOff, endOff - 6);
-                    dt.ns = parseNum(input, endOff - 6, endOff) * 1000;
-                    break;
-                case "nanosecond":
-                    dt.unixsecond = parseNum(input, startOff, endOff - 9);
-                    dt.ns = parseNum(input, endOff - 9, endOff);
-                    break;
-                default:
-                    throw error(offset, "Hit invalid standard rule: " + matcher.re());
-            }
-        }
-    }
+	/**
+	 * Execute datetime's parsing
+	 */
+	private void parse(final CharArray input) {
+		matcher.reset(input);
+		int offset = 0;
+		int oldEnd = -1;
+		while (matcher.find(offset)) {
+			if (oldEnd == matcher.end()) {
+				throw error(offset, "empty matching at " + offset);
+			}
+			if (standardRules.contains(matcher.re())) {
+				this.parseStandard(input, offset);
+			}
+			else {
+				RuleHandler handler = customizedRuleMap.get(matcher.re());
+				handler.handle(input, matcher, dt);
+			}
+			offset = matcher.end();
+			oldEnd = offset;
+		}
+		if (offset != input.length()) {
+			throw error(offset);
+		}
+	}
 
-    /**
-     * Parse an subsequence which represent dd/mm or mm/dd, it should be more smart for different locales.
-     */
-    void parseDayOrMonth(CharArray input, int from, int to) {
-        char next = input.data[from + 1];
-        int a, b;
-        if (next < '0' || next > '9') {
-            a = parseNum(input, from, from + 1);
-            b = parseNum(input, from + 2, to);
-        } else {
-            a = parseNum(input, from, from + 2);
-            b = parseNum(input, from + 3, to);
-        }
-        if (a > 31 || b > 31 || a == 0 || b == 0 || (a > 12 && b > 12)) {
-            throw error(from, "Invalid DayOrMonth at " + from);
-        }
-        if (b > 12 || preferMonthFirst) {
-            dt.month = a;
-            dt.day = b;
-        } else {
-            dt.day = a;
-            dt.month = b;
-        }
-    }
+	/**
+	 * Parse datetime use standard rules.
+	 */
+	void parseStandard(CharArray input, int offset) {
+		for (int index = 1; index <= matcher.groupCount(); index++) {
+			final String groupName = matcher.groupName(index);
+			final int startOff = matcher.start(index);
+			final int endOff = matcher.end(index);
+			if (groupName == null) {
+				throw error(offset, "Hit invalid standard rule: " + matcher.re());
+			}
+			if (startOff == -1 && endOff == -1) {
+				continue;
+			}
+			switch (groupName) {
+				case "week":
+					dt.week = parseWeek(input, startOff);
+					break;
+				case "year":
+					dt.year = parseYear(input, startOff, endOff);
+					break;
+				case "month":
+					dt.month = parseMonth(input, startOff, endOff);
+					if (dt.month <= 0 || dt.month > 12) {
+						throw error(startOff, "Invalid month at " + startOff);
+					}
+					break;
+				case "day":
+					dt.day = parseNum(input, startOff, endOff);
+					if (dt.day <= 0 || dt.day > 31) {
+						throw error(startOff, "Invalid day at " + startOff);
+					}
+					break;
+				case "hour":
+					dt.hour = parseNum(input, startOff, endOff);
+					if (dt.hour >= 24) {
+						throw error(startOff, "Invalid hour at " + startOff);
+					}
+					break;
+				case "minute":
+					dt.minute = parseNum(input, startOff, endOff);
+					if (dt.minute >= 60) {
+						throw error(startOff, "Invalid minute at " + startOff);
+					}
+					break;
+				case "second":
+					dt.second = parseNum(input, startOff, endOff);
+					if (dt.second >= 60) {
+						throw error(startOff, "Invalid second at " + startOff);
+					}
+					break;
+				case "ns":
+					dt.ns = parseNano(input, startOff, endOff);
+					break;
+				case "m":
+					if (input.charAt(startOff) == 'p') {
+						dt.pm = true;
+					}
+					else {
+						dt.am = true;
+					}
+					break;
+				case "zero":
+					dt.zoneOffsetSetted = true;
+					dt.zoneOffset = 0;
+					break;
+				case "zoneOffset":
+					dt.zoneOffsetSetted = true;
+					dt.zoneOffset = parseZoneOffset(input, startOff, endOff);
+					if (dt.zoneOffset < -1080 || dt.zoneOffset > 1080) {
+						throw error(startOff, "Invalid ZoneOffset at " + startOff);
+					}
+					break;
+				case "zoneName":
+					// don't support by now
+					break;
+				case "dayOrMonth":
+					parseDayOrMonth(input, startOff, endOff);
+					break;
+				case "unixsecond":
+					dt.unixsecond = parseNum(input, startOff, startOff + 10);
+					break;
+				case "millisecond":
+					dt.unixsecond = parseNum(input, startOff, endOff - 3);
+					dt.ns = parseNum(input, endOff - 3, endOff) * 1000000;
+					break;
+				case "microsecond":
+					dt.unixsecond = parseNum(input, startOff, endOff - 6);
+					dt.ns = parseNum(input, endOff - 6, endOff) * 1000;
+					break;
+				case "nanosecond":
+					dt.unixsecond = parseNum(input, startOff, endOff - 9);
+					dt.ns = parseNum(input, endOff - 9, endOff);
+					break;
+				default:
+					throw error(offset, "Hit invalid standard rule: " + matcher.re());
+			}
+		}
+	}
 
-    /**
-     * Parse an subsequence which represent year, like '2019', '19' etc
-     */
-    int parseYear(CharArray input, int from, int to) {
-        switch (to - from) {
-            case 4:
-                return parseNum(input, from, to);
-            case 2:
-                int num = parseNum(input, from, to);
-                return (num > 50 ? 1900 : 2000) + num;
-            case 0:
-                return 0;
-            default:
-                throw error(from, "Invalid year at " + from);
-        }
-    }
+	/**
+	 * Parse an subsequence which represent dd/mm or mm/dd, it should be more smart for different locales.
+	 */
+	void parseDayOrMonth(CharArray input, int from, int to) {
+		char next = input.data[from + 1];
+		int a, b;
+		if (next < '0' || next > '9') {
+			a = parseNum(input, from, from + 1);
+			b = parseNum(input, from + 2, to);
+		}
+		else {
+			a = parseNum(input, from, from + 2);
+			b = parseNum(input, from + 3, to);
+		}
+		if (a > 31 || b > 31 || a == 0 || b == 0 || (a > 12 && b > 12)) {
+			throw error(from, "Invalid DayOrMonth at " + from);
+		}
+		if (b > 12 || preferMonthFirst) {
+			dt.month = a;
+			dt.day = b;
+		}
+		else {
+			dt.day = a;
+			dt.month = b;
+		}
+	}
 
-    /**
-     * Parse an subsequence which represent the offset of timezone, like '+0800', '+08', '+8:00', '+08:00' etc
-     */
-    int parseZoneOffset(CharArray input, int from, int to) {
-        boolean neg = input.data[from] == '-';
-        from++;
-        // parse hour
-        int hour;
-        if (from + 2 <= to && Character.isDigit(input.charAt(from + 1))) {
-            hour = parseNum(input, from, from + 2);
-            from += 2;
-        } else {
-            hour = parseNum(input, from, from + 1);
-            from += 1;
-        }
-        // skip ':' optionally
-        if (from + 3 <= to && input.charAt(from) == ':') {
-            from++;
-        }
-        // parse minute optionally
-        int minute = 0;
-        if (from + 2 <= to) {
-            minute = parseNum(input, from, from + 2);
-        }
-        return (hour * 60 + minute) * (neg ? -1 : 1);
-    }
+	/**
+	 * Parse an subsequence which represent year, like '2019', '19' etc
+	 */
+	int parseYear(CharArray input, int from, int to) {
+		switch (to - from) {
+			case 4:
+				return parseNum(input, from, to);
+			case 2:
+				int num = parseNum(input, from, to);
+				return (num > 50 ? 1900 : 2000) + num;
+			case 0:
+				return 0;
+			default:
+				throw error(from, "Invalid year at " + from);
+		}
+	}
 
-    /**
-     * Parse an subsequence which suffix second, like '.2000', '.3186369', '.257000000' etc
-     * It should be treated as ms/us/ns.
-     */
-    int parseNano(CharArray input, int from, int to) {
-        int len = to - from;
-        if (len < 1) {
-            return 0;
-        }
-        int num = parseNum(input, from, to);
-        return NSS[len - 1] * num;
-    }
+	/**
+	 * Parse an subsequence which represent the offset of timezone, like '+0800', '+08', '+8:00', '+08:00' etc
+	 */
+	int parseZoneOffset(CharArray input, int from, int to) {
+		boolean neg = input.data[from] == '-';
+		from++;
+		// parse hour
+		int hour;
+		if (from + 2 <= to && Character.isDigit(input.charAt(from + 1))) {
+			hour = parseNum(input, from, from + 2);
+			from += 2;
+		}
+		else {
+			hour = parseNum(input, from, from + 1);
+			from += 1;
+		}
+		// skip ':' optionally
+		if (from + 3 <= to && input.charAt(from) == ':') {
+			from++;
+		}
+		// parse minute optionally
+		int minute = 0;
+		if (from + 2 <= to) {
+			minute = parseNum(input, from, from + 2);
+		}
+		return (hour * 60 + minute) * (neg ? -1 : 1);
+	}
 
-    /**
-     * Parse an subsequence which represent week, like 'Monday', 'mon' etc
-     */
-    int parseWeek(CharArray input, int from) {
-        switch (input.data[from]) {
-            case 'm':
-                return 1; // monday
-            case 'w':
-                return 3; // wednesday
-            case 'f':
-                return 5; // friday
-            case 't':
-                switch (input.data[from + 1]) {
-                    case 'u':
-                        return 2; // tuesday
-                    case 'h':
-                        return 4; // thursday
-                }
-                break;
-            case 's':
-                switch (input.data[from + 1]) {
-                    case 'a':
-                        return 6; // saturday
-                    case 'u':
-                        return 7; // sunday
-                }
-                break;
-        }
-        throw error(from, "Invalid week at " + from);
-    }
+	/**
+	 * Parse an subsequence which suffix second, like '.2000', '.3186369', '.257000000' etc
+	 * It should be treated as ms/us/ns.
+	 */
+	int parseNano(CharArray input, int from, int to) {
+		int len = to - from;
+		if (len < 1) {
+			return 0;
+		}
+		int num = parseNum(input, from, to);
+		return NSS[len - 1] * num;
+	}
 
-    /**
-     * Parse an subsequence which represent month, like '12', 'Feb' etc
-     */
-    int parseMonth(CharArray input, int from, int to) {
-        if (to - from <= 2) {
-            return parseNum(input, from, to);
-        }
-        switch (input.data[from]) {
-            case 'a':
-                switch (input.data[from + 1]) {
-                    case 'p':
-                        return 4; // april
-                    case 'u':
-                        return 8; // august
-                }
-                break;
-            case 'j':
-                if (input.data[from + 1] == 'a') {
-                    return 1; // january
-                }
-                switch (input.data[from + 2]) {
-                    case 'n':
-                        return 6; // june
-                    case 'l':
-                        return 7; // july
-                }
-                break;
-            case 'f':
-                return 2; // february
-            case 'm':
-                switch (input.data[from + 2]) {
-                    case 'r':
-                        return 3; // march
-                    case 'y':
-                        return 5; // may
-                }
-                break;
-            case 's':
-                return 9; // september
-            case 'o':
-                return 10; // october
-            case 'n':
-                return 11; // november
-            case 'd':
-                return 12; // december
-        }
-        throw error(from, "Invalid month at " + from);
-    }
+	/**
+	 * Parse an subsequence which represent week, like 'Monday', 'mon' etc
+	 */
+	int parseWeek(CharArray input, int from) {
+		switch (input.data[from]) {
+			case 'm':
+				return 1; // monday
+			case 'w':
+				return 3; // wednesday
+			case 'f':
+				return 5; // friday
+			case 't':
+				switch (input.data[from + 1]) {
+					case 'u':
+						return 2; // tuesday
+					case 'h':
+						return 4; // thursday
+				}
+				break;
+			case 's':
+				switch (input.data[from + 1]) {
+					case 'a':
+						return 6; // saturday
+					case 'u':
+						return 7; // sunday
+				}
+				break;
+		}
+		throw error(from, "Invalid week at " + from);
+	}
 
-    private DateTimeParseException error(int offset) {
-        return error(offset, String.format("Text %s cannot parse at %d", input, offset));
-    }
+	/**
+	 * Parse an subsequence which represent month, like '12', 'Feb' etc
+	 */
+	int parseMonth(CharArray input, int from, int to) {
+		if (to - from <= 2) {
+			return parseNum(input, from, to);
+		}
+		switch (input.data[from]) {
+			case 'a':
+				switch (input.data[from + 1]) {
+					case 'p':
+						return 4; // april
+					case 'u':
+						return 8; // august
+				}
+				break;
+			case 'j':
+				if (input.data[from + 1] == 'a') {
+					return 1; // january
+				}
+				switch (input.data[from + 2]) {
+					case 'n':
+						return 6; // june
+					case 'l':
+						return 7; // july
+				}
+				break;
+			case 'f':
+				return 2; // february
+			case 'm':
+				switch (input.data[from + 2]) {
+					case 'r':
+						return 3; // march
+					case 'y':
+						return 5; // may
+				}
+				break;
+			case 's':
+				return 9; // september
+			case 'o':
+				return 10; // october
+			case 'n':
+				return 11; // november
+			case 'd':
+				return 12; // december
+		}
+		throw error(from, "Invalid month at " + from);
+	}
 
-    private DateTimeParseException error(int offset, String msg) {
-        return new DateTimeParseException(msg, input, offset);
-    }
+	private DateTimeParseException error(int offset) {
+		return error(offset, String.format("Text %s cannot parse at %d", input, offset));
+	}
 
-    /**
-     * Parse an subsequence which represent an number, like '1234'
-     */
-    static int parseNum(CharArray input, int from, int to) {
-        int num = 0;
-        for (int i = from; i < to; i++) {
-            num = num * 10 + (input.data[i] - '0');
-        }
-        return num;
-    }
+	private DateTimeParseException error(int offset, String msg) {
+		return new DateTimeParseException(msg, input, offset);
+	}
 
-    static CharArray buildInput(String str) {
-        if (str == null) {
-            throw new NullPointerException("str cannot be null");
-        }
-        if (str.length() == 0) {
-            throw new IllegalArgumentException("str cannot be empty");
-        }
-        char[] chars = str.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            char ch = chars[i];
-            if (ch >= 'A' && ch <= 'Z') {
-                chars[i] = (char) (ch + 32);
-            }
-        }
-        return new CharArray(chars);
-    }
+	/**
+	 * Parse an subsequence which represent an number, like '1234'
+	 */
+	static int parseNum(CharArray input, int from, int to) {
+		int num = 0;
+		for (int i = from; i < to; i++) {
+			num = num * 10 + (input.data[i] - '0');
+		}
+		return num;
+	}
 
-    static class CharArray implements CharSequence {
+	static CharArray buildInput(String str) {
+		if (str == null) {
+			throw new NullPointerException("str cannot be null");
+		}
+		if (str.length() == 0) {
+			throw new IllegalArgumentException("str cannot be empty");
+		}
+		char[] chars = str.toCharArray();
+		for (int i = 0; i < chars.length; i++) {
+			char ch = chars[i];
+			if (ch >= 'A' && ch <= 'Z') {
+				chars[i] = (char) (ch + 32);
+			}
+		}
+		return new CharArray(chars);
+	}
 
-        char[] data;
+	static class CharArray implements CharSequence {
 
-        public CharArray(char[] data) {
-            this.data = data;
-        }
+		char[] data;
 
-        @Override
-        public int length() {
-            return data.length;
-        }
+		public CharArray(char[] data) {
+			this.data = data;
+		}
 
-        @Override
-        public char charAt(int index) {
-            return data[index];
-        }
+		@Override
+		public int length() {
+			return data.length;
+		}
 
-        @Override
-        public CharSequence subSequence(int start, int end) {
-            throw new UnsupportedOperationException();
-        }
-    }
+		@Override
+		public char charAt(int index) {
+			return data[index];
+		}
 
-    private static final int[] NSS = {100000000, 10000000, 1000000, 100000, 10000, 1000, 100, 10, 1};
+		@Override
+		public CharSequence subSequence(int start, int end) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static final int[] NSS = { 100000000, 10000000, 1000000, 100000, 10000, 1000, 100, 10, 1 };
 }

--- a/src/main/java/com/github/sisyphsu/dateparser/DateParserUtils.java
+++ b/src/main/java/com/github/sisyphsu/dateparser/DateParserUtils.java
@@ -13,80 +13,84 @@ import java.util.Date;
  */
 public final class DateParserUtils {
 
-    private DateParserUtils() {
-    }
+	private DateParserUtils() {
+	}
 
-    private static final DateParserBuilder builder = DateParser.newBuilder();
-    private static DateParser dateParser = builder.build();
+	private static final DateParserBuilder builder = DateParser.newBuilder();
+	private static DateParser dateParser = builder.build();
 
-    /**
-     * Parse the specified String into Date instance, it will convert different TimeZone into system's default zone.
-     *
-     * @param str Datetime string like '2019-10-01 00:10:20 +0800'
-     * @return Parsed datetime as Date
-     */
-    public static synchronized Date parseDate(String str) {
-        return dateParser.parseDate(str);
-    }
+	/**
+	 * Parse the specified String into Date instance, it will convert different TimeZone into system's default zone.
+	 *
+	 * @param str Datetime string like '2019-10-01 00:10:20 +0800'
+	 * @return Parsed datetime as Date
+	 */
+	public static synchronized Date parseDate(String str) {
+		return dateParser.parseDate(str);
+	}
 
-    /**
-     * Parse the specified String into Calendar instance, it will convert different TimeZone into system's default zone.
-     *
-     * @param str Datetime string like '2019-10-01 00:10:20 +0800'
-     * @return Parsed datetime as Calendar
-     */
-    public static synchronized Calendar parseCalendar(String str) {
-        return dateParser.parseCalendar(str);
-    }
+	public static synchronized Date parseDate2(String str) {
+		return dateParser.parseDate2(str);
+	}
 
-    /**
-     * Parse the specified String into LocalDateTime, it will convert different TimeZone into system's default zone.
-     *
-     * @param str Datetime string like '2019-10-01 +08:00'
-     * @return Parsed datetime as LocalDateTime
-     */
-    public static synchronized LocalDateTime parseDateTime(String str) {
-        return dateParser.parseDateTime(str);
-    }
+	/**
+	 * Parse the specified String into Calendar instance, it will convert different TimeZone into system's default zone.
+	 *
+	 * @param str Datetime string like '2019-10-01 00:10:20 +0800'
+	 * @return Parsed datetime as Calendar
+	 */
+	public static synchronized Calendar parseCalendar(String str) {
+		return dateParser.parseCalendar(str);
+	}
 
-    /**
-     * Parse the specified String into OffsetDateTime, use +00:00 as default ZoneOffset.
-     *
-     * @param str Datetime string like '2019-10-01'
-     * @return Parsed datetime as OffsetDateTime
-     */
-    public static synchronized OffsetDateTime parseOffsetDateTime(String str) {
-        return dateParser.parseOffsetDateTime(str);
-    }
+	/**
+	 * Parse the specified String into LocalDateTime, it will convert different TimeZone into system's default zone.
+	 *
+	 * @param str Datetime string like '2019-10-01 +08:00'
+	 * @return Parsed datetime as LocalDateTime
+	 */
+	public static synchronized LocalDateTime parseDateTime(String str) {
+		return dateParser.parseDateTime(str);
+	}
 
-    /**
-     * Setup the current Utils prefer mm/dd or not.
-     *
-     * @param preferMonthFirst Prefer dd/mm or mm/dd
-     */
-    public static synchronized void preferMonthFirst(boolean preferMonthFirst) {
-        dateParser.setPreferMonthFirst(preferMonthFirst);
-    }
+	/**
+	 * Parse the specified String into OffsetDateTime, use +00:00 as default ZoneOffset.
+	 *
+	 * @param str Datetime string like '2019-10-01'
+	 * @return Parsed datetime as OffsetDateTime
+	 */
+	public static synchronized OffsetDateTime parseOffsetDateTime(String str) {
+		return dateParser.parseOffsetDateTime(str);
+	}
 
-    /**
-     * Register new standard parse rules, all captured group should have the specified names.
-     *
-     * @param re The regex of rule
-     */
-    public static synchronized void registerStandardRule(String re) {
-        builder.addRule(re);
-        dateParser = builder.build();
-    }
+	/**
+	 * Setup the current Utils prefer mm/dd or not.
+	 *
+	 * @param preferMonthFirst Prefer dd/mm or mm/dd
+	 */
+	public static synchronized void preferMonthFirst(boolean preferMonthFirst) {
+		dateParser.setPreferMonthFirst(preferMonthFirst);
+	}
 
-    /**
-     * Register new customized parse rules.
-     *
-     * @param re      The regex of rule, like '\d{8}'
-     * @param handler The handler for this rule
-     */
-    public static synchronized void registerCustomizedRule(String re, RuleHandler handler) {
-        builder.addRule(re, handler);
-        dateParser = builder.build();
-    }
+	/**
+	 * Register new standard parse rules, all captured group should have the specified names.
+	 *
+	 * @param re The regex of rule
+	 */
+	public static synchronized void registerStandardRule(String re) {
+		builder.addRule(re);
+		dateParser = builder.build();
+	}
+
+	/**
+	 * Register new customized parse rules.
+	 *
+	 * @param re      The regex of rule, like '\d{8}'
+	 * @param handler The handler for this rule
+	 */
+	public static synchronized void registerCustomizedRule(String re, RuleHandler handler) {
+		builder.addRule(re, handler);
+		dateParser = builder.build();
+	}
 
 }

--- a/src/test/java/com/github/sisyphsu/dateparser/DateParserTest.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/DateParserTest.java
@@ -1,11 +1,12 @@
 package com.github.sisyphsu.dateparser;
 
-import org.junit.jupiter.api.Test;
-
 import java.time.Month;
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author sulin
@@ -13,166 +14,205 @@ import java.time.format.DateTimeFormatterBuilder;
  */
 public class DateParserTest {
 
-    private DateParser parser = DateParser.newBuilder().preferMonthFirst(true).build();
+	private final DateParser parser = DateParser.newBuilder().preferMonthFirst(true).build();
 
-    @Test
-    public void test() {
-        OffsetDateTime dateTime = parser.parseOffsetDateTime("12 o’clock PM, PDT");
-        assert dateTime.getHour() == 12;
+	@Test
+	public void test_showsDstProblem() {
+		// parsing with sisyphsu lib
+		long epochTime1 = DateParserUtils.parseDate("2015-02-18 00:12:00 +0000 GMT").getTime();
 
-        dateTime = parser.parseOffsetDateTime("0:08 PM, CEST");
-        assert dateTime.getHour() == 12;
-        assert dateTime.getMinute() == 8;
+		// parsing with Java parser
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z");
+		ZonedDateTime zonedDateTime = ZonedDateTime.parse("2015-02-18 00:12:00 +0000", formatter);
+		long epochTime2 = zonedDateTime.toInstant().toEpochMilli();
 
-        dateTime = parser.parseOffsetDateTime("2018-09-16T08:00:00+00:00[Europe/London]");
-        assert dateTime.getYear() == 2018;
-        assert dateTime.getMonth() == Month.SEPTEMBER;
-        assert dateTime.getDayOfMonth() == 16;
-        assert dateTime.getHour() == 8;
-        assert dateTime.getOffset().getTotalSeconds() == 0;
+		// in my case next line outputs is: >> DIFF=[3600] sec
+		System.out.print(String.format("\nDIFF=[%s] sec\n", Math.abs(epochTime2 - epochTime1) / 1000));
 
-        dateTime = parser.parseOffsetDateTime("Mon Sep 16 2019 10:44:33 GMT+0800 (中国标准时间)");
-        assert dateTime.getYear() == 2019;
-        assert dateTime.getMonth() == Month.SEPTEMBER;
-        assert dateTime.getDayOfMonth() == 16;
-    }
+		// expected to be equal, but on machine with a time zone where Daylight Saving Time is present it shows 1h difference
+		// fails!!!
+		assert epochTime1 == epochTime2;
+	}
 
-    @Test
-    public void testCharArray() {
-        DateParser.CharArray array = new DateParser.CharArray(new char[0]);
-        assert array.length() == 0;
-        try {
-            array.subSequence(0, 0);
-            assert false;
-        } catch (Exception e) {
-            assert e instanceof UnsupportedOperationException;
-        }
-    }
+	@Test
+	public void test_fixedDstProblem() {
+		// parsing with sisyphsu lib (new fixed method)
+		long epochTime1 = DateParserUtils.parseDate2("2015-02-18 00:12:00 +0000 GMT").getTime();
 
-    @Test
-    public void allTest() {
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2009-05-08 17:57:51 +0000", "May 8, 2009 5:57:51 PM");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct 7, 1970");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct 7, '70");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct. 7, 1970");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct. 7, 70");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 +0000", "Mon Jan  2 15:04:05 2006");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon Jan  2 15:04:05 MST 2006");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon Jan 02 15:04:05 -0700 2006");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Monday, 02-Jan-06 15:04:05 MST");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon, 02 Jan 2006 15:04:05 MST");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2017-07-11 16:28:13 +0200", "Tue, 11 Jul 2017 16:28:13 +0200 (CEST)");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon, 02 Jan 2006 15:04:05 -0700");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2018-01-04 17:53:36 +0000", "Thu, 4 Jan 2018 17:53:36 +0000");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2015-08-10 15:44:11 +0100", "Mon Aug 10 15:44:11 UTC+0100 2015");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2018-01-04 17:53:36 +0000", "Thu, 4 Jan 2018 17:53:36 +0000");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2015-08-10 15:44:11 +0100", "Mon Aug 10 15:44:11 UTC+0100 2015");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2015-07-03 18:04:07 +0100", "Fri Jul 03 2015 18:04:07 GMT+0100 (GMT Daylight Time)");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:09:00 +0000", "September 17, 2012 10:09am");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:09:00 -0800", "September 17, 2012 at 10:09am PST-08");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:10:09 +0000", "September 17, 2012, 10:10:09");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "October 7, 1970");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "October 7th, 1970");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-02-12 19:17:00 +0000", "12 Feb 2006, 19:17");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-02-12 19:17:00 +0000", "12 Feb 2006 19:17");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "7 oct 70");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "7 oct 1970");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 00:00:00 +0000", "03 February 2013");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2013-07-01 00:00:00 +0000", "1 July 2013");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 00:00:00 +0000", "2013-Feb-03");
+		// parsing with Java parser
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z");
+		ZonedDateTime zonedDateTime = ZonedDateTime.parse("2015-02-18 00:12:00 +0000", formatter);
+		long epochTime2 = zonedDateTime.toInstant().toEpochMilli();
 
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3/31/2014");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "03/31/2014");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 00:00:00 +0000", "08/21/71");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-01 00:00:00 +0000", "8/1/71");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "4/8/2014 22:05");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "04/08/2014 22:05");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "4/8/14 22:05");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "04/2/2014 03:00:51");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "04/2/2014 03:00:51");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 00:00:00 +0000", "8/8/1965 12:00:00 AM");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:01 +0000", "8/8/1965 01:00:01 PM");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:00 +0000", "8/8/1965 01:00 PM");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:00 +0000", "8/8/1965 1:00 PM");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 00:00:00 +0000", "8/8/1965 12:00 AM");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "4/02/2014 03:00:51");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "4/02/2014 03:00:51");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "03/19/2012 10:11:59");
-        assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 10:11:59.318636 +0000", "03/19/2012 10:11:59.318636");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "2014/3/31");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "2014/03/31");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "2014/4/8 22:05");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "2014/04/08 22:05");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "2014/04/2 03:00:51");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "2014/4/02 03:00:51");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "2012/03/19 10:11:59");
-        assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 10:11:59.318636 +0000", "2012/03/19 10:11:59.318636");
+		System.out.print(String.format("\nDIFF=[%s] sec\n", Math.abs(epochTime2 - epochTime1) / 1000));
 
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 00:00:00 +0000", "2014年04月08日");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 +0000", "2006-01-02T15:04:05+0000");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 -0700", "2009-08-12T22:15:09-07:00");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 +0000", "2009-08-12T22:15:09");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 +0000", "2009-08-12T22:15:09Z");
-        assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2014-04-26 17:24:37.318636 +0000", "2014-04-26 17:24:37.318636");
-        assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2012-08-03 18:31:59.257 +0000", "2012-08-03 18:31:59.257000000");
-        assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-04-26 17:24:37.123 +0000", "2014-04-26 17:24:37.123");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2013-04-01 22:43:00 +0000", "2013-04-01 22:43");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2013-04-01 22:43:22 +0000", "2013-04-01 22:43:22");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-12-16 06:20:00 +0000", "2014-12-16 06:20:00 UTC");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-12-16 06:20:00 +0000", "2014-12-16 06:20:00 GMT");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 17:24:37 +0000", "2014-04-26 05:24:37 PM");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:43 +0800", "2014-04-26 13:13:43 +0800");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:43 +0800", "2014-04-26 13:13:43 +0800 +08");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:44 +0900", "2014-04-26 13:13:44 +09:00");
-        assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2012-08-03 18:31:59.257 +0000", "2012-08-03 18:31:59.257000000 +0000 UTC");
-        assert match("yyyy-MM-dd HH:mm:ss.SSSSSSSS Z", "2015-09-30 18:48:56.35272715 +0000", "2015-09-30 18:48:56.35272715 +0000 UTC");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-18 00:12:00 +0000", "2015-02-18 00:12:00 +0000 GMT");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-18 00:12:00 +0000", "2015-02-18 00:12:00 +0000 UTC");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-08 03:02:00 +0300", "2015-02-08 03:02:00 +0300 MSK m=+0.000000001");
-        assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2015-02-08 03:02:00.001 +0300", "2015-02-08 03:02:00.001 +0300 MSK m=+0.000000001");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2017-07-19 03:21:51 +0000", "2017-07-19 03:21:51+00:00");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 00:00:00 +0000", "2014-04-26");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-01 00:00:00 +0000", "2014-04");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-01-01 00:00:00 +0000", "2014");
-        assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-05-11 08:20:13.787 +0000", "2014-05-11 08:20:13,787");
+		// expected to be equal
+		assert epochTime1 == epochTime2;
+	}
 
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3。31.2014");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3.31.2014");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "03.31.2014");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 00:00:00 +0000", "08.21.71");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-01 00:00:00 +0000", "2014.03");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +0000", "2014.03.30");
+	@Test
+	public void test() {
+		OffsetDateTime dateTime = parser.parseOffsetDateTime("12 o’clock PM, PDT");
+		assert dateTime.getHour() == 12;
 
-        // test ZoneOffset
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 -1400", "2014.03.30 00:00:00 -1400");
-        assert matchStamp("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 14:00:00 +0000", "2014.03.30 00:00:00 -1400");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +1300", "2014.03.30 00:00:00 +1300");
-        assert matchStamp("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +0000", "2014.03.30 13:00:00 +1300");
+		dateTime = parser.parseOffsetDateTime("0:08 PM, CEST");
+		assert dateTime.getHour() == 12;
+		assert dateTime.getMinute() == 8;
 
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-06-01 00:00:00 +0000", "20140601");
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-07-22 10:52:03 +0000", "20140722105203");
+		dateTime = parser.parseOffsetDateTime("2018-09-16T08:00:00+00:00[Europe/London]");
+		assert dateTime.getYear() == 2018;
+		assert dateTime.getMonth() == Month.SEPTEMBER;
+		assert dateTime.getDayOfMonth() == 16;
+		assert dateTime.getHour() == 8;
+		assert dateTime.getOffset().getTotalSeconds() == 0;
 
-        assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "1332151919");
-        assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2013-11-12 00:32:47.189 +0000", "1384216367189");
-        assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2013-11-12 00:32:47.111222 +0000", "1384216367111222");
-        assert match("yyyy-MM-dd HH:mm:ss.SSSSSSSSS Z", "2013-11-12 00:32:47.111222333 +0000", "1384216367111222333");
-    }
+		dateTime = parser.parseOffsetDateTime("Mon Sep 16 2019 10:44:33 GMT+0800 (中国标准时间)");
+		assert dateTime.getYear() == 2019;
+		assert dateTime.getMonth() == Month.SEPTEMBER;
+		assert dateTime.getDayOfMonth() == 16;
+	}
 
-    private boolean match(String format, String datetime, String freeDatetime) {
-        DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format).toFormatter();
-        OffsetDateTime dt1 = OffsetDateTime.parse(datetime, formatter);
-        OffsetDateTime dt2 = parser.parseOffsetDateTime(freeDatetime);
+	@Test
+	public void testCharArray() {
+		DateParser.CharArray array = new DateParser.CharArray(new char[0]);
+		assert array.length() == 0;
+		try {
+			array.subSequence(0, 0);
+			assert false;
+		}
+		catch (Exception e) {
+			assert e instanceof UnsupportedOperationException;
+		}
+	}
 
-        return dt1.equals(dt2);
-    }
+	@Test
+	public void allTest() {
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-05-08 17:57:51 +0000", "May 8, 2009 5:57:51 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct 7, 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct 7, '70");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct. 7, 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct. 7, 70");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 +0000", "Mon Jan  2 15:04:05 2006");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon Jan  2 15:04:05 MST 2006");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon Jan 02 15:04:05 -0700 2006");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Monday, 02-Jan-06 15:04:05 MST");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon, 02 Jan 2006 15:04:05 MST");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2017-07-11 16:28:13 +0200", "Tue, 11 Jul 2017 16:28:13 +0200 (CEST)");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon, 02 Jan 2006 15:04:05 -0700");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2018-01-04 17:53:36 +0000", "Thu, 4 Jan 2018 17:53:36 +0000");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-08-10 15:44:11 +0100", "Mon Aug 10 15:44:11 UTC+0100 2015");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2018-01-04 17:53:36 +0000", "Thu, 4 Jan 2018 17:53:36 +0000");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-08-10 15:44:11 +0100", "Mon Aug 10 15:44:11 UTC+0100 2015");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-07-03 18:04:07 +0100",
+				"Fri Jul 03 2015 18:04:07 GMT+0100 (GMT Daylight Time)");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:09:00 +0000", "September 17, 2012 10:09am");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:09:00 -0800", "September 17, 2012 at 10:09am PST-08");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:10:09 +0000", "September 17, 2012, 10:10:09");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "October 7, 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "October 7th, 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-02-12 19:17:00 +0000", "12 Feb 2006, 19:17");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-02-12 19:17:00 +0000", "12 Feb 2006 19:17");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "7 oct 70");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "7 oct 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 00:00:00 +0000", "03 February 2013");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-07-01 00:00:00 +0000", "1 July 2013");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 00:00:00 +0000", "2013-Feb-03");
 
-    private boolean matchStamp(String format, String datetime, String freeDatetime) {
-        DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format).toFormatter();
-        OffsetDateTime dt1 = OffsetDateTime.parse(datetime, formatter);
-        OffsetDateTime dt2 = parser.parseOffsetDateTime(freeDatetime);
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3/31/2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "03/31/2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 00:00:00 +0000", "08/21/71");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-01 00:00:00 +0000", "8/1/71");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "4/8/2014 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "04/08/2014 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "4/8/14 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "04/2/2014 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "04/2/2014 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 00:00:00 +0000", "8/8/1965 12:00:00 AM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:01 +0000", "8/8/1965 01:00:01 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:00 +0000", "8/8/1965 01:00 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:00 +0000", "8/8/1965 1:00 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 00:00:00 +0000", "8/8/1965 12:00 AM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "4/02/2014 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "4/02/2014 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "03/19/2012 10:11:59");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 10:11:59.318636 +0000", "03/19/2012 10:11:59.318636");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "2014/3/31");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "2014/03/31");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "2014/4/8 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "2014/04/08 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "2014/04/2 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "2014/4/02 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "2012/03/19 10:11:59");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 10:11:59.318636 +0000", "2012/03/19 10:11:59.318636");
 
-        return dt1.toEpochSecond() == dt2.toEpochSecond();
-    }
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 00:00:00 +0000", "2014年04月08日");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 +0000", "2006-01-02T15:04:05+0000");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 -0700", "2009-08-12T22:15:09-07:00");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 +0000", "2009-08-12T22:15:09");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 +0000", "2009-08-12T22:15:09Z");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2014-04-26 17:24:37.318636 +0000", "2014-04-26 17:24:37.318636");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2012-08-03 18:31:59.257 +0000", "2012-08-03 18:31:59.257000000");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-04-26 17:24:37.123 +0000", "2014-04-26 17:24:37.123");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-04-01 22:43:00 +0000", "2013-04-01 22:43");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-04-01 22:43:22 +0000", "2013-04-01 22:43:22");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-12-16 06:20:00 +0000", "2014-12-16 06:20:00 UTC");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-12-16 06:20:00 +0000", "2014-12-16 06:20:00 GMT");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 17:24:37 +0000", "2014-04-26 05:24:37 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:43 +0800", "2014-04-26 13:13:43 +0800");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:43 +0800", "2014-04-26 13:13:43 +0800 +08");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:44 +0900", "2014-04-26 13:13:44 +09:00");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2012-08-03 18:31:59.257 +0000",
+				"2012-08-03 18:31:59.257000000 +0000 UTC");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSSSS Z", "2015-09-30 18:48:56.35272715 +0000",
+				"2015-09-30 18:48:56.35272715 +0000 UTC");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-18 00:12:00 +0000", "2015-02-18 00:12:00 +0000 GMT");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-18 00:12:00 +0000", "2015-02-18 00:12:00 +0000 UTC");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-08 03:02:00 +0300",
+				"2015-02-08 03:02:00 +0300 MSK m=+0.000000001");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2015-02-08 03:02:00.001 +0300",
+				"2015-02-08 03:02:00.001 +0300 MSK m=+0.000000001");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2017-07-19 03:21:51 +0000", "2017-07-19 03:21:51+00:00");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 00:00:00 +0000", "2014-04-26");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-01 00:00:00 +0000", "2014-04");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-01-01 00:00:00 +0000", "2014");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-05-11 08:20:13.787 +0000", "2014-05-11 08:20:13,787");
 
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3。31.2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3.31.2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "03.31.2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 00:00:00 +0000", "08.21.71");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-01 00:00:00 +0000", "2014.03");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +0000", "2014.03.30");
+
+		// test ZoneOffset
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 -1400", "2014.03.30 00:00:00 -1400");
+		assert matchStamp("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 14:00:00 +0000", "2014.03.30 00:00:00 -1400");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +1300", "2014.03.30 00:00:00 +1300");
+		assert matchStamp("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +0000", "2014.03.30 13:00:00 +1300");
+
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-06-01 00:00:00 +0000", "20140601");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-07-22 10:52:03 +0000", "20140722105203");
+
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "1332151919");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2013-11-12 00:32:47.189 +0000", "1384216367189");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2013-11-12 00:32:47.111222 +0000", "1384216367111222");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSSSSS Z", "2013-11-12 00:32:47.111222333 +0000", "1384216367111222333");
+	}
+
+	private boolean match(String format, String datetime, String freeDatetime) {
+		DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format).toFormatter();
+		OffsetDateTime dt1 = OffsetDateTime.parse(datetime, formatter);
+		OffsetDateTime dt2 = parser.parseOffsetDateTime(freeDatetime);
+
+		return dt1.equals(dt2);
+	}
+
+	private boolean matchStamp(String format, String datetime, String freeDatetime) {
+		DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format).toFormatter();
+		OffsetDateTime dt1 = OffsetDateTime.parse(datetime, formatter);
+		OffsetDateTime dt2 = parser.parseOffsetDateTime(freeDatetime);
+
+		return dt1.toEpochSecond() == dt2.toEpochSecond();
+	}
 
 }

--- a/src/test/java/com/github/sisyphsu/dateparser/DateParserTest.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/DateParserTest.java
@@ -16,23 +16,23 @@ public class DateParserTest {
 
 	private final DateParser parser = DateParser.newBuilder().preferMonthFirst(true).build();
 
-	@Test
-	public void test_showsDstProblem() {
-		// parsing with sisyphsu lib
-		long epochTime1 = DateParserUtils.parseDate("2015-02-18 00:12:00 +0000 GMT").getTime();
-
-		// parsing with Java parser
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z");
-		ZonedDateTime zonedDateTime = ZonedDateTime.parse("2015-02-18 00:12:00 +0000", formatter);
-		long epochTime2 = zonedDateTime.toInstant().toEpochMilli();
-
-		// in my case next line outputs is: >> DIFF=[3600] sec
-		System.out.print(String.format("\nDIFF=[%s] sec\n", Math.abs(epochTime2 - epochTime1) / 1000));
-
-		// expected to be equal, but on machine with a time zone where Daylight Saving Time is present it shows 1h difference
-		// fails!!!
-		assert epochTime1 == epochTime2;
-	}
+	//	@Test
+	//	public void test_showsDstProblem() {
+	//		// parsing with sisyphsu lib
+	//		long epochTime1 = DateParserUtils.parseDate("2015-02-18 00:12:00 +0000 GMT").getTime();
+	//
+	//		// parsing with Java parser
+	//		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z");
+	//		ZonedDateTime zonedDateTime = ZonedDateTime.parse("2015-02-18 00:12:00 +0000", formatter);
+	//		long epochTime2 = zonedDateTime.toInstant().toEpochMilli();
+	//
+	//		// in my case next line outputs is: >> DIFF=[3600] sec
+	//		System.out.print(String.format("\nDIFF=[%s] sec\n", Math.abs(epochTime2 - epochTime1) / 1000));
+	//
+	//		// expected to be equal, but on machine with a time zone where Daylight Saving Time is present it shows 1h difference
+	//		// fails!!!
+	//		assert epochTime1 == epochTime2;
+	//	}
 
 	@Test
 	public void test_fixedDstProblem() {

--- a/src/test/java/com/github/sisyphsu/dateparser/DateParserTest2.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/DateParserTest2.java
@@ -4,25 +4,44 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.TimeZone;
 
 import org.junit.jupiter.api.Test;
 
 /**
  * @author sulin
  * @since 2019-09-15 15:32:10
+ * 
+ * History of changes:
+ * 
+ * - 15.08.2021 - 
+ * Use the same input as from other files to use UTC expected and tested Date. Otherwise
+ * data has to be changed depending on time zone where the test runs.
+ * Force system time zone to avoid potential test result deviation from time zone where the 
+ * test runs.
+ * Note: the test shows unexpected result when parseDate2() is replaced by parseDate()
+ * 
  */
 public class DateParserTest2 {
+	
+
+	{
+		// set time zone for the test
+		TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+	}
 
 	private final DateParser parser = DateParser.newBuilder().preferMonthFirst(true).build();
 
 	@Test
 	public void allTest2() {
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-05-08 21:57:51 +0000", "May 8, 2009 5:57:51 PM");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "oct 7, 1970");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "oct 7, '70");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "oct. 7, 1970");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "oct. 7, 70");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 20:04:05 +0000", "Mon Jan  2 15:04:05 2006");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2009-05-08 17:57:51 +0000", "May 8, 2009 5:57:51 PM");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct 7, 1970");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct 7, '70");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct. 7, 1970");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "oct. 7, 70");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 +0000", "Mon Jan  2 15:04:05 2006");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon Jan  2 15:04:05 MST 2006");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon Jan 02 15:04:05 -0700 2006");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Monday, 02-Jan-06 15:04:05 MST");
@@ -33,59 +52,60 @@ public class DateParserTest2 {
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-08-10 15:44:11 +0100", "Mon Aug 10 15:44:11 UTC+0100 2015");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2018-01-04 17:53:36 +0000", "Thu, 4 Jan 2018 17:53:36 +0000");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-08-10 15:44:11 +0100", "Mon Aug 10 15:44:11 UTC+0100 2015");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-07-03 18:04:07 +0100",
-				"Fri Jul 03 2015 18:04:07 GMT+0100 (GMT Daylight Time)");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 14:09:00 +0000", "September 17, 2012 10:09am");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-07-03 18:04:07 +0100", "Fri Jul 03 2015 18:04:07 GMT+0100 (GMT Daylight Time)");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:09:00 +0000", "September 17, 2012 10:09am");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:09:00 -0800", "September 17, 2012 at 10:09am PST-08");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 14:10:09 +0000", "September 17, 2012, 10:10:09");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "October 7, 1970");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "October 7th, 1970");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-02-13 00:17:00 +0000", "12 Feb 2006, 19:17");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-02-13 00:17:00 +0000", "12 Feb 2006 19:17");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "7 oct 70");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "7 oct 1970");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 05:00:00 +0000", "03 February 2013");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-07-01 04:00:00 +0000", "1 July 2013");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 05:00:00 +0000", "2013-Feb-03");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "3/31/2014");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "03/31/2014");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 04:00:00 +0000", "08/21/71");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-01 04:00:00 +0000", "8/1/71");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "4/8/2014 22:05");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "04/08/2014 22:05");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "4/8/14 22:05");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "04/2/2014 03:00:51");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "04/2/2014 03:00:51");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 04:00:00 +0000", "8/8/1965 12:00:00 AM");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 17:00:01 +0000", "8/8/1965 01:00:01 PM");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 17:00:00 +0000", "8/8/1965 01:00 PM");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 17:00:00 +0000", "8/8/1965 1:00 PM");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 04:00:00 +0000", "8/8/1965 12:00 AM");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "4/02/2014 03:00:51");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "4/02/2014 03:00:51");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 14:11:59 +0000", "03/19/2012 10:11:59");
-		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 14:11:59.318636 +0000", "03/19/2012 10:11:59.318636");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "2014/3/31");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "2014/03/31");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "2014/4/8 22:05");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "2014/04/08 22:05");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "2014/04/2 03:00:51");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "2014/4/02 03:00:51");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 14:11:59 +0000", "2012/03/19 10:11:59");
-		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 14:11:59.318636 +0000", "2012/03/19 10:11:59.318636");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 04:00:00 +0000", "2014年04月08日");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:10:09 +0000", "September 17, 2012, 10:10:09");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "October 7, 1970");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "October 7th, 1970");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2006-02-12 19:17:00 +0000", "12 Feb 2006, 19:17");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2006-02-12 19:17:00 +0000", "12 Feb 2006 19:17");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "7 oct 70");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 00:00:00 +0000", "7 oct 1970");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 00:00:00 +0000", "03 February 2013");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2013-07-01 00:00:00 +0000", "1 July 2013");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 00:00:00 +0000", "2013-Feb-03");
+
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3/31/2014");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "03/31/2014");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 00:00:00 +0000", "08/21/71");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1971-08-01 00:00:00 +0000", "8/1/71");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "4/8/2014 22:05");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "04/08/2014 22:05");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "4/8/14 22:05");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "04/2/2014 03:00:51");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "04/2/2014 03:00:51");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 00:00:00 +0000", "8/8/1965 12:00:00 AM");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:01 +0000", "8/8/1965 01:00:01 PM");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:00 +0000", "8/8/1965 01:00 PM");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 13:00:00 +0000", "8/8/1965 1:00 PM");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 00:00:00 +0000", "8/8/1965 12:00 AM");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "4/02/2014 03:00:51");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "4/02/2014 03:00:51");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "03/19/2012 10:11:59");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 10:11:59.318636 +0000", "03/19/2012 10:11:59.318636");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "2014/3/31");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "2014/03/31");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "2014/4/8 22:05");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 22:05:00 +0000", "2014/04/08 22:05");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "2014/04/2 03:00:51");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 03:00:51 +0000", "2014/4/02 03:00:51");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "2012/03/19 10:11:59");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 10:11:59.318636 +0000", "2012/03/19 10:11:59.318636");
+
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 00:00:00 +0000", "2014年04月08日");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 +0000", "2006-01-02T15:04:05+0000");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 -0700", "2009-08-12T22:15:09-07:00");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-13 02:15:09 +0000", "2009-08-12T22:15:09");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 +0000", "2009-08-12T22:15:09");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 +0000", "2009-08-12T22:15:09Z");
-		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2014-04-26 21:24:37.318636 +0000", "2014-04-26 17:24:37.318636");
-		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2012-08-03 22:31:59.257 +0000", "2012-08-03 18:31:59.257000000");
-		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-04-26 21:24:37.123 +0000", "2014-04-26 17:24:37.123");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-04-02 02:43:00 +0000", "2013-04-01 22:43");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-04-02 02:43:22 +0000", "2013-04-01 22:43:22");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2014-04-26 17:24:37.318636 +0000", "2014-04-26 17:24:37.318636");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss.SSS Z", "2012-08-03 18:31:59.257 +0000", "2012-08-03 18:31:59.257000000");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-04-26 17:24:37.123 +0000", "2014-04-26 17:24:37.123");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2013-04-01 22:43:00 +0000", "2013-04-01 22:43");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2013-04-01 22:43:22 +0000", "2013-04-01 22:43:22");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-12-16 06:20:00 +0000", "2014-12-16 06:20:00 UTC");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-12-16 06:20:00 +0000", "2014-12-16 06:20:00 GMT");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 21:24:37 +0000", "2014-04-26 05:24:37 PM");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 17:24:37 +0000", "2014-04-26 05:24:37 PM");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:43 +0800", "2014-04-26 13:13:43 +0800");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:43 +0800", "2014-04-26 13:13:43 +0800 +08");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:44 +0900", "2014-04-26 13:13:44 +09:00");
@@ -100,24 +120,27 @@ public class DateParserTest2 {
 		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2015-02-08 03:02:00.001 +0300",
 				"2015-02-08 03:02:00.001 +0300 MSK m=+0.000000001");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2017-07-19 03:21:51 +0000", "2017-07-19 03:21:51+00:00");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 04:00:00 +0000", "2014-04-26");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-01 04:00:00 +0000", "2014-04");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-01-01 05:00:00 +0000", "2014");
-		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-05-11 12:20:13.787 +0000", "2014-05-11 08:20:13,787");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "3。31.2014");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "3.31.2014");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "03.31.2014");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 04:00:00 +0000", "08.21.71");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-01 05:00:00 +0000", "2014.03");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 04:00:00 +0000", "2014.03.30");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 00:00:00 +0000", "2014-04-26");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-04-01 00:00:00 +0000", "2014-04");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-01-01 00:00:00 +0000", "2014");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-05-11 08:20:13.787 +0000", "2014-05-11 08:20:13,787");
+
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3。31.2014");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "3.31.2014");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 00:00:00 +0000", "03.31.2014");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 00:00:00 +0000", "08.21.71");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-01 00:00:00 +0000", "2014.03");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +0000", "2014.03.30");
 
 		// test ZoneOffset
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 -1400", "2014.03.30 00:00:00 -1400");
 		assert matchStamp("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 14:00:00 +0000", "2014.03.30 00:00:00 -1400");
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +1300", "2014.03.30 00:00:00 +1300");
 		assert matchStamp("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +0000", "2014.03.30 13:00:00 +1300");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-06-01 04:00:00 +0000", "20140601");
-		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-07-22 14:52:03 +0000", "20140722105203");
+
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-06-01 00:00:00 +0000", "20140601");
+		assert matchNoTz("yyyy-MM-dd HH:mm:ss Z", "2014-07-22 10:52:03 +0000", "20140722105203");
+
 		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "1332151919");
 		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2013-11-12 00:32:47.189 +0000", "1384216367189");
 		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2013-11-12 00:32:47.111222 +0000", "1384216367111222");
@@ -128,10 +151,33 @@ public class DateParserTest2 {
 		DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format).toFormatter();
 		OffsetDateTime dt1 = OffsetDateTime.parse(datetime, formatter);
 		Date d1 = Date.from(dt1.toInstant());
-		Date d2 = parser.parseDate2(freeDatetime);
+		Date d2 = parser.parseDate2(freeDatetime); // to reveal the problem, use parseDate(..) instead of parseDate2(..)
+		return d1.equals(d2);
+	}
 
-		boolean result = d1.equals(d2);
-		return result;
+
+	/**
+	 * Note: comparing to {@link #match(String, String, String)} this method removes time zone information 
+	 * from parsed <code>freeDatetime</code> when comparing to expected date
+	 * @param format template format for <code>datetime</code>
+	 * @param datetime expected date
+	 * @param freeDatetime date string to compare with expected date
+	 * @return true if expected date is the same as freeDatetime
+	 */
+	private boolean matchNoTz(String format, String datetime, String freeDatetime) {
+		DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format).toFormatter();
+		OffsetDateTime dt1 = OffsetDateTime.parse(datetime, formatter);
+		Date d1 = Date.from(dt1.toInstant());
+		// note: d1 is always in UTC
+		
+		// it is expected that parseDate(..) method uses a system default time zone if the time zone is not specified in parsed text
+		Date d2 = parser.parseDate2(freeDatetime);
+		// remove local time zone offset, to compare result with expected UTC time
+		long offset = TimeZone.getDefault().getOffset(d2.getTime());
+		Date d3 = new Date(d2.getTime() + offset);
+
+
+		return d1.equals(d3);
 	}
 
 	private boolean matchStamp(String format, String datetime, String freeDatetime) {
@@ -141,5 +187,4 @@ public class DateParserTest2 {
 
 		return dt1.toEpochSecond() == dt2.toEpochSecond();
 	}
-
 }

--- a/src/test/java/com/github/sisyphsu/dateparser/DateParserTest2.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/DateParserTest2.java
@@ -1,0 +1,145 @@
+package com.github.sisyphsu.dateparser;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author sulin
+ * @since 2019-09-15 15:32:10
+ */
+public class DateParserTest2 {
+
+	private final DateParser parser = DateParser.newBuilder().preferMonthFirst(true).build();
+
+	@Test
+	public void allTest2() {
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-05-08 21:57:51 +0000", "May 8, 2009 5:57:51 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "oct 7, 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "oct 7, '70");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "oct. 7, 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "oct. 7, 70");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 20:04:05 +0000", "Mon Jan  2 15:04:05 2006");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon Jan  2 15:04:05 MST 2006");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon Jan 02 15:04:05 -0700 2006");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Monday, 02-Jan-06 15:04:05 MST");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon, 02 Jan 2006 15:04:05 MST");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2017-07-11 16:28:13 +0200", "Tue, 11 Jul 2017 16:28:13 +0200 (CEST)");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 -0700", "Mon, 02 Jan 2006 15:04:05 -0700");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2018-01-04 17:53:36 +0000", "Thu, 4 Jan 2018 17:53:36 +0000");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-08-10 15:44:11 +0100", "Mon Aug 10 15:44:11 UTC+0100 2015");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2018-01-04 17:53:36 +0000", "Thu, 4 Jan 2018 17:53:36 +0000");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-08-10 15:44:11 +0100", "Mon Aug 10 15:44:11 UTC+0100 2015");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-07-03 18:04:07 +0100",
+				"Fri Jul 03 2015 18:04:07 GMT+0100 (GMT Daylight Time)");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 14:09:00 +0000", "September 17, 2012 10:09am");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 10:09:00 -0800", "September 17, 2012 at 10:09am PST-08");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-09-17 14:10:09 +0000", "September 17, 2012, 10:10:09");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "October 7, 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "October 7th, 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-02-13 00:17:00 +0000", "12 Feb 2006, 19:17");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-02-13 00:17:00 +0000", "12 Feb 2006 19:17");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "7 oct 70");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1970-10-07 04:00:00 +0000", "7 oct 1970");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 05:00:00 +0000", "03 February 2013");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-07-01 04:00:00 +0000", "1 July 2013");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-02-03 05:00:00 +0000", "2013-Feb-03");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "3/31/2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "03/31/2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 04:00:00 +0000", "08/21/71");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-01 04:00:00 +0000", "8/1/71");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "4/8/2014 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "04/08/2014 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "4/8/14 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "04/2/2014 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "04/2/2014 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 04:00:00 +0000", "8/8/1965 12:00:00 AM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 17:00:01 +0000", "8/8/1965 01:00:01 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 17:00:00 +0000", "8/8/1965 01:00 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 17:00:00 +0000", "8/8/1965 1:00 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1965-08-08 04:00:00 +0000", "8/8/1965 12:00 AM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "4/02/2014 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "4/02/2014 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 14:11:59 +0000", "03/19/2012 10:11:59");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 14:11:59.318636 +0000", "03/19/2012 10:11:59.318636");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "2014/3/31");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "2014/03/31");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "2014/4/8 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-09 02:05:00 +0000", "2014/04/08 22:05");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "2014/04/2 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-02 07:00:51 +0000", "2014/4/02 03:00:51");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 14:11:59 +0000", "2012/03/19 10:11:59");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2012-03-19 14:11:59.318636 +0000", "2012/03/19 10:11:59.318636");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-08 04:00:00 +0000", "2014年04月08日");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2006-01-02 15:04:05 +0000", "2006-01-02T15:04:05+0000");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 -0700", "2009-08-12T22:15:09-07:00");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-13 02:15:09 +0000", "2009-08-12T22:15:09");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2009-08-12 22:15:09 +0000", "2009-08-12T22:15:09Z");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2014-04-26 21:24:37.318636 +0000", "2014-04-26 17:24:37.318636");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2012-08-03 22:31:59.257 +0000", "2012-08-03 18:31:59.257000000");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-04-26 21:24:37.123 +0000", "2014-04-26 17:24:37.123");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-04-02 02:43:00 +0000", "2013-04-01 22:43");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2013-04-02 02:43:22 +0000", "2013-04-01 22:43:22");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-12-16 06:20:00 +0000", "2014-12-16 06:20:00 UTC");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-12-16 06:20:00 +0000", "2014-12-16 06:20:00 GMT");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 21:24:37 +0000", "2014-04-26 05:24:37 PM");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:43 +0800", "2014-04-26 13:13:43 +0800");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:43 +0800", "2014-04-26 13:13:43 +0800 +08");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:44 +0900", "2014-04-26 13:13:44 +09:00");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2012-08-03 18:31:59.257 +0000",
+				"2012-08-03 18:31:59.257000000 +0000 UTC");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSSSS Z", "2015-09-30 18:48:56.35272715 +0000",
+				"2015-09-30 18:48:56.35272715 +0000 UTC");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-18 00:12:00 +0000", "2015-02-18 00:12:00 +0000 GMT");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-18 00:12:00 +0000", "2015-02-18 00:12:00 +0000 UTC");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2015-02-08 03:02:00 +0300",
+				"2015-02-08 03:02:00 +0300 MSK m=+0.000000001");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2015-02-08 03:02:00.001 +0300",
+				"2015-02-08 03:02:00.001 +0300 MSK m=+0.000000001");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2017-07-19 03:21:51 +0000", "2017-07-19 03:21:51+00:00");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 04:00:00 +0000", "2014-04-26");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-01 04:00:00 +0000", "2014-04");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-01-01 05:00:00 +0000", "2014");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2014-05-11 12:20:13.787 +0000", "2014-05-11 08:20:13,787");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "3。31.2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "3.31.2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-31 04:00:00 +0000", "03.31.2014");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "1971-08-21 04:00:00 +0000", "08.21.71");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-01 05:00:00 +0000", "2014.03");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 04:00:00 +0000", "2014.03.30");
+
+		// test ZoneOffset
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 -1400", "2014.03.30 00:00:00 -1400");
+		assert matchStamp("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 14:00:00 +0000", "2014.03.30 00:00:00 -1400");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +1300", "2014.03.30 00:00:00 +1300");
+		assert matchStamp("yyyy-MM-dd HH:mm:ss Z", "2014-03-30 00:00:00 +0000", "2014.03.30 13:00:00 +1300");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-06-01 04:00:00 +0000", "20140601");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2014-07-22 14:52:03 +0000", "20140722105203");
+		assert match("yyyy-MM-dd HH:mm:ss Z", "2012-03-19 10:11:59 +0000", "1332151919");
+		assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2013-11-12 00:32:47.189 +0000", "1384216367189");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2013-11-12 00:32:47.111222 +0000", "1384216367111222");
+		assert match("yyyy-MM-dd HH:mm:ss.SSSSSSSSS Z", "2013-11-12 00:32:47.111222333 +0000", "1384216367111222333");
+	}
+
+	private boolean match(String format, String datetime, String freeDatetime) {
+		DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format).toFormatter();
+		OffsetDateTime dt1 = OffsetDateTime.parse(datetime, formatter);
+		Date d1 = Date.from(dt1.toInstant());
+		Date d2 = parser.parseDate2(freeDatetime);
+
+		boolean result = d1.equals(d2);
+		return result;
+	}
+
+	private boolean matchStamp(String format, String datetime, String freeDatetime) {
+		DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format).toFormatter();
+		OffsetDateTime dt1 = OffsetDateTime.parse(datetime, formatter);
+		OffsetDateTime dt2 = parser.parseOffsetDateTime(freeDatetime);
+
+		return dt1.toEpochSecond() == dt2.toEpochSecond();
+	}
+
+}


### PR DESCRIPTION
To revial the problem of Daylight Saving Time(DST), you can uncomment the test case: DateParserTest.test_showsDstProblem()
Also, I think that the problem is visible only when it runs on machine with time zone where DST is active during the test. For example on machine with regional settings of time zone where the it has DST activated (summer period)

To avoid backward compatibility problem I didn't change the internal implementation of DateBuilder.toDate() method wher the original time zone offset computation is done. Instead I try to add a new method with expected (fixed) fixed behaviour.

Let me know if you need more information,
Regards,
Andriy