### PR TITLE
Fixed issue #19: Exception when non-zero minutes negative time zone....

### DIFF
--- a/src/main/java/com/github/sisyphsu/dateparser/DateBuilder.java
+++ b/src/main/java/com/github/sisyphsu/dateparser/DateBuilder.java
@@ -134,7 +134,7 @@ public final class DateBuilder {
         LocalDateTime dateTime = LocalDateTime.of(year, month, day, hour, minute, second, ns);
         // with ZoneOffset
         if (zoneOffsetSetted) {
-            ZoneOffset offset = ZoneOffset.ofHoursMinutes(zoneOffset / 60, Math.abs(zoneOffset % 60));
+            ZoneOffset offset = ZoneOffset.ofHoursMinutes(zoneOffset / 60, zoneOffset % 60);
             return dateTime.atOffset(offset);
         }
         // with TimeZone

--- a/src/test/java/com/github/sisyphsu/dateparser/DateParserTest.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/DateParserTest.java
@@ -156,6 +156,10 @@ public class DateParserTest {
         assert match("yyyy-MM-dd HH:mm:ss.SSS Z", "2013-11-12 00:32:47.189 +0000", "1384216367189");
         assert match("yyyy-MM-dd HH:mm:ss.SSSSSS Z", "2013-11-12 00:32:47.111222 +0000", "1384216367111222");
         assert match("yyyy-MM-dd HH:mm:ss.SSSSSSSSS Z", "2013-11-12 00:32:47.111222333 +0000", "1384216367111222333");
+
+        // non-zero minutes negative time zone test
+        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:44 -0230", "2014-04-26 13:13:44 -02:30");
+        assert match("yyyy-MM-dd HH:mm:ss Z", "2014-04-26 13:13:44 -0930", "2014-04-26 13:13:44 -09:30");
     }
 
     private boolean match(String format, String datetime, String freeDatetime) {


### PR DESCRIPTION
The commit has fix for: Negative time zone with non-zero minutes raise an error: "Zone offset minutes and seconds must be negative because hours is negative"

(DateBuilder.java)
- method toOffsetDateTime() When parsed time zone is negative, it is also expected to have negative number of minutes. The method ZoneOffset.ofHoursMinutes(..) accepts negative offset with negative minutes only. The method ZoneOffset.ofHoursMinutes(..) raise an exception when hours are negative and minutes are positive. Solution: remove Math.abs(..) from minutes parameter.

(DateParserTest.java)
- Add test cases for negative time zone with non-zero minutes.