### PR TITLE
Fixed DST problem for dates with time zone indicator

### DIFF
--- a/src/main/java/com/github/sisyphsu/dateparser/DateBuilder.java
+++ b/src/main/java/com/github/sisyphsu/dateparser/DateBuilder.java
@@ -65,10 +65,7 @@ public final class DateBuilder {
         if (!zoneOffsetSetted) {
             return toCalendar().getTime();
         }
-        LocalDateTime dateTime = toLocalDateTime();
-        long second = dateTime.toEpochSecond(DEFAULT_OFFSET);
-        long ns = dateTime.getNano();
-        return new Date(second * 1000 + ns / 1000000);
+        return Date.from(toOffsetDateTime().toInstant());
     }
 
     /**


### PR DESCRIPTION
Problem: when date with time zone indicator is parsed by
DateBuilder.parseDate(String) the local DST (Daylight saving time)
affects the parsed result by DST offset of local JVM.
The expected behaviour is: when parsed date has a time zone indication
then the parsed date must respect only time zone offset of parsed date. The
TimeZone of locale JVM must not affect the parsed result.

(DateBuilder.java)
- remove local related computation if time zone indication is present in
  parsed date

(DateParserTest.java)
- add test case for dates with/without time zone indicator. The date is
  parsed in any available time zone. Note: without fix in
  DateBuilder.java the test fails for date with time zone information

P.S.
It is expected that this fix solves the issue #8(Strange timezone offsets)
