### PR TITLE
Improve performance when parsing many strings in the same format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 hs_err_pid*
 .idea
 *.iml
+
+# Output folder of IntelliJ
+target

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.sisyphsu</groupId>
-    <artifactId>dateparser-xyzt-ai</artifactId>
+    <artifactId>dateparser</artifactId>
     <version>1.0.11</version>
 
     <name>dateparser</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.sisyphsu</groupId>
-    <artifactId>dateparser</artifactId>
+    <artifactId>dateparser-xyzt-ai</artifactId>
     <version>1.0.11</version>
 
     <name>dateparser</name>

--- a/src/main/java/com/github/sisyphsu/dateparser/DateParserBuilder.java
+++ b/src/main/java/com/github/sisyphsu/dateparser/DateParserBuilder.java
@@ -145,6 +145,8 @@ public final class DateParserBuilder {
     }
 
     private boolean preferMonthFirst = false;
+    private boolean optimizeForReuseSimilarFormatted = false;
+
     private final List<String> rules = new ArrayList<>();
     private final Set<String> standardRules = new HashSet<>();
     private final Map<String, RuleHandler> customizedRuleMap = new HashMap<>();
@@ -156,6 +158,18 @@ public final class DateParserBuilder {
         // predefined customized rules
         this.rules.addAll(DateParserBuilder.CUSTOMIZED_RULES);
         this.customizedRuleMap.putAll(DateParserBuilder.CUSTOMIZED_RULE_MAP);
+    }
+
+    /**
+     * Set to {@code true} when the parser will be used to parse many date strings which all use the same format.
+     * An example use-case is parsing a timestamp column from a large CSV file.
+     *
+     * @param optimizeForReuseSimilarFormatted True means creating a parser optimized to parse many date strings in the same format.
+     * @return This
+     */
+    public DateParserBuilder optimizeForReuseSimilarFormatted(boolean optimizeForReuseSimilarFormatted){
+        this.optimizeForReuseSimilarFormatted = optimizeForReuseSimilarFormatted;
+        return this;
     }
 
     /**
@@ -204,7 +218,7 @@ public final class DateParserBuilder {
      * @return DateParser
      */
     public DateParser build() {
-        return new DateParser(rules, standardRules, customizedRuleMap, preferMonthFirst);
+        return new DateParser(rules, standardRules, customizedRuleMap, preferMonthFirst, optimizeForReuseSimilarFormatted);
     }
 
 }

--- a/src/test/java/com/github/sisyphsu/dateparser/DateBuilderTest.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/DateBuilderTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.util.Date;
+import java.util.Random;
 import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author sulin
@@ -122,4 +125,23 @@ public class DateBuilderTest {
         assert date.getTime() == Long.valueOf(timestamp);
     }
 
+    @Test
+    public void testOptimizeForReuseSimilarFormatted(){
+        Random random = new Random(123456789l);
+        String[] inputs = new String[500000];
+        for (int i = 0; i < inputs.length; i++) {
+            inputs[i] = String.format("2020-0%d-1%d 00:%d%d:00 UTC",
+              random.nextInt(8) + 1,
+              random.nextInt(8) + 1,
+              random.nextInt(5),
+              random.nextInt(9));
+        }
+        DateParser regular = DateParser.newBuilder().build();
+        DateParser optimized = DateParser.newBuilder().optimizeForReuseSimilarFormatted(true).build();
+
+        for (int i = 0; i < inputs.length; i++) {
+            String input = inputs[i];
+            assertEquals(regular.parseDate(input), optimized.parseDate(input));
+        }
+    }
 }

--- a/src/test/java/com/github/sisyphsu/dateparser/DateBuilderTest.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/DateBuilderTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.util.Date;
+import java.util.Random;
 import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author sulin
@@ -127,4 +130,23 @@ public class DateBuilderTest {
         assert date.getTime() == Long.valueOf(timestamp);
     }
 
+    @Test
+    public void testOptimizeForReuseSimilarFormatted(){
+        Random random = new Random(123456789l);
+        String[] inputs = new String[500000];
+        for (int i = 0; i < inputs.length; i++) {
+            inputs[i] = String.format("2020-0%d-1%d 00:%d%d:00 UTC",
+              random.nextInt(8) + 1,
+              random.nextInt(8) + 1,
+              random.nextInt(5),
+              random.nextInt(9));
+        }
+        DateParser regular = DateParser.newBuilder().build();
+        DateParser optimized = DateParser.newBuilder().optimizeForReuseSimilarFormatted(true).build();
+
+        for (int i = 0; i < inputs.length; i++) {
+            String input = inputs[i];
+            assertEquals(regular.parseDate(input), optimized.parseDate(input));
+        }
+    }
 }

--- a/src/test/java/com/github/sisyphsu/dateparser/DateBuilderTest.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/DateBuilderTest.java
@@ -148,5 +148,13 @@ public class DateBuilderTest {
             String input = inputs[i];
             assertEquals(regular.parseDate(input), optimized.parseDate(input));
         }
+
+        //Now check if the parser can still deal with a date in a different format
+        String inputInDifferentFormat = String.format("1%d/0%d/2020 00:%d%d:00 UTC",
+          random.nextInt(8) + 1,
+          random.nextInt(8) + 1,
+          random.nextInt(5),
+          random.nextInt(9));
+        assertEquals(regular.parseDate(inputInDifferentFormat), optimized.parseDate(inputInDifferentFormat));
     }
 }

--- a/src/test/java/com/github/sisyphsu/dateparser/benchmark/OptimizeForReuseSimilarFormattedBenchmark.java
+++ b/src/test/java/com/github/sisyphsu/dateparser/benchmark/OptimizeForReuseSimilarFormattedBenchmark.java
@@ -1,0 +1,44 @@
+package com.github.sisyphsu.dateparser.benchmark;
+
+import com.github.sisyphsu.dateparser.DateParser;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 2, time = 2)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(2)
+@Measurement(iterations = 3, time = 3)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class OptimizeForReuseSimilarFormattedBenchmark {
+  private static final String[] TEXTS;
+
+  static {
+    Random random = new Random(123456789l);
+    TEXTS = new String[500000];
+    for (int i = 0; i < TEXTS.length; i++) {
+      TEXTS[i] = String.format("2020-0%d-1%d 00:%d%d:00 UTC",
+        random.nextInt(8) + 1,
+        random.nextInt(8) + 1,
+        random.nextInt(5),
+        random.nextInt(9));
+    }
+  }
+
+  @Benchmark
+  public void regularParser() {
+    DateParser parser = DateParser.newBuilder().build();
+    for (String text : TEXTS) {
+      parser.parseDate(text);
+    }
+  }
+
+  @Benchmark
+  public void optimizedForReuseParser() {
+    DateParser parser = DateParser.newBuilder().optimizeForReuseSimilarFormatted(true).build();
+    for (String text : TEXTS) {
+      parser.parseDate(text);
+    }
+  }
+}


### PR DESCRIPTION
Proposal for https://github.com/sisyphsu/dateparser/issues/17 .

By keeping track of which rules were used to parse the first string, parsing the next strings can try to use a matcher that only uses a subset of those rules.

The case in the benchmark is between 2 and 3 times faster on my machine:
```
Benchmark                                                          Mode  Cnt     Score     Error  Units
OptimizeForReuseSimilarFormattedBenchmark.optimizedForReuseParser  avgt    6   462.362 ±  54.300  ms/op
OptimizeForReuseSimilarFormattedBenchmark.regularParser            avgt    6  1130.171 ± 162.117  ms/op
```