### PR TITLE
Ensure Lombok is not included transitively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- test -->


### PR DESCRIPTION
Fixes #30. That is, ensures that other tools that rely on dateparser do not unnecessarily include the entire Lombok library.

[As explained in the Maven FAQ](https://maven.apache.org/general.html#scope-provided):

> **How do I prevent including JARs in WEB-INF/lib? I need a "compile only" scope!**
>
> The scope you should use for this is `provided`. This indicates to Maven that the dependency will be provided at run time by its container or the JDK, for example.
>
> Dependencies with this scope will not be passed on transitively, nor will they be bundled in a package such as a WAR, or included in the runtime classpath. 